### PR TITLE
Login-hotfix

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,7 +15,8 @@ import {SpecificUser} from './page/SpecificUser';
 function App() {
   const [loggedInUser, setLoggedInUser] = useState({"username": "", "roles": "", "email": ""});
   const [search, setSearch] = useState("");
-  const [tokenIsValid, setTokenIsValid] = useState(null);
+  const [tokenIsValid, setTokenIsValid] = useState(false);
+  const [currentToken, setCurrentToken] = useState("");
   
   
   useEffect(() => {
@@ -38,6 +39,14 @@ function App() {
       localStorage.removeItem("token");
       return;
     }
+
+    if(currentToken !== token){
+      alert("Token has expired, please log in again");
+      setTokenIsValid(false);
+      localStorage.removeItem("token");
+      return;
+    }
+
     setTokenIsValid(true);
     setLoggedInUser({username: tokenData.username, roles: tokenData.roles, email: tokenData.email});
     console.log("Token is valid");
@@ -70,7 +79,7 @@ function App() {
 
           {/*These routes are exempt from the AppLayout component */}
           <Route index element={<Navigate to="/login"/>}/>   
-          <Route path="/login" element={<Login setLoggedInUser={setLoggedInUser} loggedInUser={loggedInUser}/>}/>
+          <Route path="/login" element={<Login setLoggedInUser={setLoggedInUser} loggedInUser={loggedInUser} setTokenIsValid={setTokenIsValid} setCurrentToken={setCurrentToken}/>}/>
           <Route path="/register" element={<Register setLoggedInUser={setLoggedInUser} />}/>
           <Route path="*" element={<PageNotFound/>}/>
         </Routes>

--- a/src/page/Login.jsx
+++ b/src/page/Login.jsx
@@ -113,17 +113,19 @@ const ErrorText = styled.p`
     margin-bottom: 1rem;
 `
 
-export const Login = ({ loggedInUser, setLoggedInUser }) => {
+export const Login = ({ loggedInUser, setLoggedInUser, setTokenIsValid, setCurrentToken }) => {
     const [error, setError] = useState(null);
     const [credentials, setCredentials] = useState({"username": "", "password": ""});
     const [showPassword, setShowPassword] = useState(false);
     const navigate = useNavigate();
 
     useEffect(() => {
-        if(loggedInUser.username){
+        if(localStorage.getItem("token") !== null && localStorage.getItem("token") !== undefined && localStorage.getItem("token") !== ""){
+            setTokenIsValid(true);
             navigate("/home");
+            console.log("I'm at login, but I'm already logged in!");
         }
-    },[loggedInUser.username]);
+    },[]);
 
 
     const handleOnChange = (e) => {
@@ -148,6 +150,8 @@ export const Login = ({ loggedInUser, setLoggedInUser }) => {
 
             setLoggedInUser({"username": data.username, "roles": data.roles, "email": data.email});
             localStorage.setItem("token", data.token);
+            setCurrentToken(data.token);
+            setTokenIsValid(true);
             navigate("/home");
         }).catch((err) => {
             setError(err.message, err.cause);

--- a/src/page/Mainpage.jsx
+++ b/src/page/Mainpage.jsx
@@ -37,7 +37,7 @@ export const Mainpage = ({search}) => {
             }
         };
         fetchData();
-    });
+    }, [navigate]);
 
     useEffect(() => {
         filterItems(search);

--- a/src/page/TokenValidator.jsx
+++ b/src/page/TokenValidator.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import { useNavigate } from 'react-router-dom';
+import {useNavigate } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
 export const TokenValidator = ({tokenIsValid, children}) => {
@@ -8,8 +8,9 @@ export const TokenValidator = ({tokenIsValid, children}) => {
   useEffect(() => {
     if(tokenIsValid === false){
       navigate("/login");
+      console.log("Im in the token validator!, token is invalid!");
     }
-  }, [tokenIsValid, navigate])
+  }, [tokenIsValid])
 
     if(tokenIsValid) return <>{children};</>
 }

--- a/src/page/accountPage.jsx
+++ b/src/page/accountPage.jsx
@@ -87,7 +87,7 @@ export const AccountPage = ({loggedInUser}) => {
 
     const handleLogout = () => {
         localStorage.removeItem("token");
-        window.location.reload();
+        navigate("/login");
     };
 
     useEffect(() => {


### PR DESCRIPTION
In App.jsx:
- Updated the initial state value of tokenIsValid to start off as false.
- Added a new state called currentToken that keeps the current valid token.
- Added a check if the currentToken state is equal to the token in our localstorage to check if it has been tampered with.
- We now send both setTokenIsValid and SetCurrentToken down to the login screen via props.

In accountPage.jsx:
- Removed the window.location.reload and replaced it with a navigate to login.

In Login.jsx:
- Added the setTokenIsValid and setCurrentToken functions to the props.
- Made a check if you're already logged in,, and go to the login screen. You now get directed to home.
- We now set the currentToken and tokenIsValid in the login function.

In Mainpage.jsx:
- we now only fetch the new posts when we navigate around.

In TokenValidtor.jsx:
- The useState only runs when tokenIsValid is updated.